### PR TITLE
make the cryptography module requirement >= 1.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import (
 
 here = os.path.dirname(__file__)
 requires = [
-    'cryptography == 1.7.2',
+    'cryptography >= 1.7.2, < 2.*',
 ]
 
 try:


### PR DESCRIPTION
to prevent build-errors on newer openssl-version