### PR TITLE
Make pip enforce python version >= 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,4 +67,5 @@ setup(
     packages=find_packages(exclude=('jwt.tests', )),
 
     install_requires=requires,
+    python_requires='>=3.4',
 )


### PR DESCRIPTION
According to the [README](https://github.com/GehirnInc/python-jwt/blob/master/README.rst) and [setup.py](https://github.com/GehirnInc/python-jwt/blob/master/setup.py), this package only supports python versions above 3.4. It'd be nice to prevent pip from installing this package under python 2 in case somebody misses the version restrictions and unexpectedly runs into weird issues later.