### PR TITLE
Issue 20/abstract jwk base should be an abc class

### DIFF
--- a/jwt/jwk.py
+++ b/jwt/jwk.py
@@ -77,6 +77,7 @@ class AbstractJWKBase(ABC):
     def to_dict(self, public_only=True):
         pass  # pragma: no cover
 
+    @classmethod
     @abstractmethod
     def from_dict(cls, dct):
         pass  # pragma: no cover

--- a/jwt/jwk.py
+++ b/jwt/jwk.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
 )
 
+from abc import ABC, abstractmethod
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -50,29 +51,35 @@ from .utils import (
 )
 
 
-class AbstractJWKBase:
+class AbstractJWKBase(ABC):
 
+    @abstractmethod
     def get_kty(self):
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
+    @abstractmethod
     def get_kid(self):
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
+    @abstractmethod
     def is_sign_key(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
+    @abstractmethod
     def sign(self, message: bytes, **options) -> bytes:
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
+    @abstractmethod
     def verify(self, message: bytes, signature: bytes, **options) -> bool:
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
+    @abstractmethod
     def to_dict(self, public_only=True):
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
-    @classmethod
+    @abstractmethod
     def from_dict(cls, dct):
-        raise NotImplementedError()  # pragma: no cover
+        pass  # pragma: no cover
 
 
 class OctetJWK(AbstractJWKBase):


### PR DESCRIPTION
# Description
1. Turns AbstractJWKBase into an ABC class
1. Turns the AbstractJWKBase's methods into abstractmethods

# fixes

fixes issue #20 