### PR TITLE
Add support for manage exp and nbf fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Examples
 
    import json
 
-   from datetime import datetime, timedelta
+   from datetime import datetime, timedelta, timezone
 
    from jwt import (
        JWT,
@@ -30,8 +30,8 @@ Examples
    message = {
        'iss': 'https://example.com/',
        'sub': 'yosida95',
-       'iat': get_int_from_datetime(datetime.utcnow()),
-       'exp': get_int_from_datetime(datetime.utcnow() + timedelta(hours=1)),
+       'iat': get_int_from_datetime(datetime.now(timezone.utc)),
+       'exp': get_int_from_datetime(datetime.now(timezone.utc) + timedelta(hours=1)),
    }
 
    with open('rsa_private_key.pem', 'rb') as fh:

--- a/README.rst
+++ b/README.rst
@@ -18,17 +18,20 @@ Examples
 
    import json
 
+   from datetime import datetime, timedelta
+
    from jwt import (
        JWT,
        jwk_from_dict,
        jwk_from_pem,
    )
+   from jwt.utils import get_time
 
    message = {
        'iss': 'https://example.com/',
        'sub': 'yosida95',
-       'iat': 1485969205,
-       'exp': 1485972805,
+       'iat': get_time(datetime.utcnow()),
+       'exp': get_time(datetime.utcnow() + timedelta(hours=1)),
    }
 
    with open('rsa_private_key.pem', 'rb') as fh:

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,13 @@ Examples
        jwk_from_dict,
        jwk_from_pem,
    )
-   from jwt.utils import get_time
+   from jwt.utils import get_int_from_datetime
 
    message = {
        'iss': 'https://example.com/',
        'sub': 'yosida95',
-       'iat': get_time(datetime.utcnow()),
-       'exp': get_time(datetime.utcnow() + timedelta(hours=1)),
+       'iat': get_int_from_datetime(datetime.utcnow()),
+       'exp': get_int_from_datetime(datetime.utcnow() + timedelta(hours=1)),
    }
 
    with open('rsa_private_key.pem', 'rb') as fh:

--- a/jwt/jwt.py
+++ b/jwt/jwt.py
@@ -17,12 +17,10 @@
 import json
 from typing import AbstractSet
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from jwt.utils import (
-    get_int_from_datetime,
     get_time_from_int,
-    get_time_from_str,
 )
 from .exceptions import (
     JWSEncodeError,
@@ -57,7 +55,7 @@ class JWT:
                do_verify=True, algorithms: AbstractSet[str] = None,
                do_time_check: bool = True) -> dict:
         # utc now with timezone
-        now = get_time_from_int(get_int_from_datetime(datetime.utcnow()))
+        now = datetime.now(timezone.utc)
         try:
             message_bin = self._jws.decode(message, key, do_verify, algorithms)
         except JWSDecodeError as why:
@@ -65,21 +63,19 @@ class JWT:
         try:
             payload = json.loads(message_bin.decode('utf-8'))
             if 'exp' in payload:
-                exp = payload.get('exp')
-                if isinstance(exp, str):
-                    exp = get_time_from_str(exp)
-                else:
-                    exp = get_time_from_int(exp)
-                if do_time_check and (exp is None or now > exp):
-                    raise JWTDecodeError("JWT Expired")
+                try:
+                    exp = get_time_from_int(payload.get('exp'))
+                    if do_time_check and (exp is None or now > exp):
+                        raise JWTDecodeError("JWT Expired")
+                except ValueError:
+                    raise JWTDecodeError("Invalid Expired value")
             if 'nbf' in payload:
-                nbf = payload.get('nbf')
-                if isinstance(nbf, str):
-                    nbf = get_time_from_str(nbf)
-                else:
-                    nbf = get_time_from_int(nbf)
-                if do_time_check and (nbf is None or now < nbf):
-                    raise JWTDecodeError("JWT Not valid yet")
+                try:
+                    nbf = get_time_from_int(payload.get('nbf'))
+                    if do_time_check and (nbf is None or now < nbf):
+                        raise JWTDecodeError("JWT Not valid yet")
+                except ValueError:
+                    raise JWTDecodeError('Invalid "Not valid yet" value')
 
             return payload
         except ValueError as why:

--- a/jwt/tests/test_jws.py
+++ b/jwt/tests/test_jws.py
@@ -17,6 +17,8 @@
 import json
 from unittest import TestCase
 
+from freezegun import freeze_time
+
 from jwt.jws import JWS
 from jwt.jwk import jwk_from_dict
 
@@ -59,6 +61,7 @@ class JWSTest(TestCase):
         message = self.inst.decode(self.compact_jws, self.key)
         self.assertEqual(message, self.message)
 
+    @freeze_time("2011-03-22 18:00:00", tz_offset=0)
     def test_decode_pubkey(self):
         message = self.inst.decode(self.compact_jws, self.pubkey)
         self.assertEqual(message, self.message)

--- a/jwt/tests/test_jwt.py
+++ b/jwt/tests/test_jwt.py
@@ -23,7 +23,7 @@ from freezegun import freeze_time
 from jwt.exceptions import JWTDecodeError
 from jwt.jwk import jwk_from_dict
 from jwt.jwt import JWT
-from jwt.utils import get_time
+from jwt.utils import get_int_from_datetime
 
 from .helper import load_testdata
 
@@ -63,7 +63,7 @@ class JWTTest(TestCase):
 
     def test_no_before_used_before(self):
         compact_jws = self.inst.encode({
-            'nbf': get_time(datetime.utcnow() + timedelta(hours=1))
+            'nbf': get_int_from_datetime(datetime.utcnow() + timedelta(hours=1))
         }, self.key)
         self.assertRaisesRegex(
             JWTDecodeError, 'JWT Not valid yet',
@@ -72,7 +72,7 @@ class JWTTest(TestCase):
 
     def test_no_before_used_after(self):
         message = {
-            'nbf': get_time(datetime.utcnow() - timedelta(hours=1))
+            'nbf': get_int_from_datetime(datetime.utcnow() - timedelta(hours=1))
         }
         compact_jws = self.inst.encode(message, self.key)
         self.assertEqual(self.inst.decode(compact_jws, self.key), message)

--- a/jwt/tests/test_jwt.py
+++ b/jwt/tests/test_jwt.py
@@ -17,7 +17,7 @@
 import json
 from unittest import TestCase
 
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 from freezegun import freeze_time
 
 from jwt.exceptions import JWTDecodeError
@@ -63,7 +63,7 @@ class JWTTest(TestCase):
 
     def test_no_before_used_before(self):
         compact_jws = self.inst.encode({
-            'nbf': get_int_from_datetime(datetime.utcnow() + timedelta(hours=1))
+            'nbf': get_int_from_datetime(datetime.now(timezone.utc) + timedelta(hours=1))
         }, self.key)
         self.assertRaisesRegex(
             JWTDecodeError, 'JWT Not valid yet',
@@ -72,7 +72,7 @@ class JWTTest(TestCase):
 
     def test_no_before_used_after(self):
         message = {
-            'nbf': get_int_from_datetime(datetime.utcnow() - timedelta(hours=1))
+            'nbf': get_int_from_datetime(datetime.now(timezone.utc) - timedelta(hours=1))
         }
         compact_jws = self.inst.encode(message, self.key)
         self.assertEqual(self.inst.decode(compact_jws, self.key), message)

--- a/jwt/tests/test_utils.py
+++ b/jwt/tests/test_utils.py
@@ -18,7 +18,9 @@ from datetime import datetime, timedelta, timezone
 from jwt.utils import (
     b64encode,
     b64decode,
-    get_time,
+    get_time_from_int,
+    get_time_from_str,
+    get_int_from_datetime,
     uint_b64encode,
     uint_b64decode,
 )
@@ -48,37 +50,45 @@ def test_uint_b64decode():
     assert uint_b64decode('AQAB') == 65537
 
 
-def test_get_time_str_wrong_format():
-    assert get_time('this is not rfc3339') is None
+def test_get_time_from_str_with_str_wrong_format():
+    assert get_time_from_str('this is not rfc3339') is None
 
 
-def test_get_time_str_leap_second():
+def test_get_time_from_str_with_str_leap_second():
     # Not supported
-    assert get_time('1990-12-31T23:59:60Z') is None
+    assert get_time_from_str('1990-12-31T23:59:60Z') is None
 
 
-def test_get_time_str_with_float():
+def test_get_time_from_str_with_str_with_float():
     expected = datetime(1985, 4, 12, 23, 20, 50, tzinfo=timezone.utc)
-    assert get_time('1985-04-12T23:20:50.52Z') == expected
+    assert get_time_from_str('1985-04-12T23:20:50.52Z') == expected
 
 
-def test_get_time_str_timezone():
+def test_get_time_from_str_with_str_timezone():
     expected = datetime(1996, 12, 19, 16, 39, 57, tzinfo=timezone.utc) + timedelta(hours=8)
-    assert get_time('1996-12-19T16:39:57-08:00') == expected
+    assert get_time_from_str('1996-12-19T16:39:57-08:00') == expected
     expected = datetime(1937, 1, 1, 12, 0, 27, tzinfo=timezone.utc) - timedelta(minutes=20)
-    assert get_time('1937-01-01T12:00:27.87+00:20') == expected
+    assert get_time_from_str('1937-01-01T12:00:27.87+00:20') == expected
 
 
-def test_get_time_str_as_int():
+def test_get_time_from_str_with_str_as_int():
     expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
-    assert get_time('1300819380') == expected
+    assert get_time_from_str('1300819380') == expected
 
 
-def test_get_time_with_int():
+def test_get_time_from_int_with_int():
     expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
-    assert get_time(1300819380) == expected
+    assert get_time_from_int(1300819380) == expected
 
 
-def test_get_time_with_datetime():
+def test_get_int_from_datetime_with_utc_timezone():
     param = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
-    assert get_time(param) == 1300819380
+    assert get_int_from_datetime(param) == 1300819380
+
+
+def test_get_int_from_datetime_with_timezone():
+    param = datetime.strptime(
+        '2011-03-22T19:43:00+0100',
+        '%Y-%m-%dT%H:%M:%S%z'
+    )
+    assert get_int_from_datetime(param) == 1300819380

--- a/jwt/tests/test_utils.py
+++ b/jwt/tests/test_utils.py
@@ -13,13 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from jwt.utils import (
     b64encode,
     b64decode,
     get_time_from_int,
-    get_time_from_str,
     get_int_from_datetime,
     uint_b64encode,
     uint_b64decode,
@@ -50,35 +49,14 @@ def test_uint_b64decode():
     assert uint_b64decode('AQAB') == 65537
 
 
-def test_get_time_from_str_with_str_wrong_format():
-    assert get_time_from_str('this is not rfc3339') is None
-
-
-def test_get_time_from_str_with_str_leap_second():
-    # Not supported
-    assert get_time_from_str('1990-12-31T23:59:60Z') is None
-
-
-def test_get_time_from_str_with_str_with_float():
-    expected = datetime(1985, 4, 12, 23, 20, 50, tzinfo=timezone.utc)
-    assert get_time_from_str('1985-04-12T23:20:50.52Z') == expected
-
-
-def test_get_time_from_str_with_str_timezone():
-    expected = datetime(1996, 12, 19, 16, 39, 57, tzinfo=timezone.utc) + timedelta(hours=8)
-    assert get_time_from_str('1996-12-19T16:39:57-08:00') == expected
-    expected = datetime(1937, 1, 1, 12, 0, 27, tzinfo=timezone.utc) - timedelta(minutes=20)
-    assert get_time_from_str('1937-01-01T12:00:27.87+00:20') == expected
-
-
-def test_get_time_from_str_with_str_as_int():
-    expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
-    assert get_time_from_str('1300819380') == expected
-
-
 def test_get_time_from_int_with_int():
     expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
     assert get_time_from_int(1300819380) == expected
+
+
+def test_get_time_from_int_with_str():
+    expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
+    assert get_time_from_int('1300819380') == expected
 
 
 def test_get_int_from_datetime_with_utc_timezone():

--- a/jwt/tests/test_utils.py
+++ b/jwt/tests/test_utils.py
@@ -13,10 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import datetime, timedelta, timezone
 
 from jwt.utils import (
     b64encode,
     b64decode,
+    get_time,
     uint_b64encode,
     uint_b64decode,
 )
@@ -44,3 +46,39 @@ def test_uint_b64encode():
 
 def test_uint_b64decode():
     assert uint_b64decode('AQAB') == 65537
+
+
+def test_get_time_str_wrong_format():
+    assert get_time('this is not rfc3339') is None
+
+
+def test_get_time_str_leap_second():
+    # Not supported
+    assert get_time('1990-12-31T23:59:60Z') is None
+
+
+def test_get_time_str_with_float():
+    expected = datetime(1985, 4, 12, 23, 20, 50, tzinfo=timezone.utc)
+    assert get_time('1985-04-12T23:20:50.52Z') == expected
+
+
+def test_get_time_str_timezone():
+    expected = datetime(1996, 12, 19, 16, 39, 57, tzinfo=timezone.utc) + timedelta(hours=8)
+    assert get_time('1996-12-19T16:39:57-08:00') == expected
+    expected = datetime(1937, 1, 1, 12, 0, 27, tzinfo=timezone.utc) - timedelta(minutes=20)
+    assert get_time('1937-01-01T12:00:27.87+00:20') == expected
+
+
+def test_get_time_str_as_int():
+    expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
+    assert get_time('1300819380') == expected
+
+
+def test_get_time_with_int():
+    expected = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
+    assert get_time(1300819380) == expected
+
+
+def test_get_time_with_datetime():
+    param = datetime(2011, 3, 22, 18, 43, tzinfo=timezone.utc)
+    assert get_time(param) == 1300819380

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -20,7 +20,6 @@ from base64 import (
 )
 
 from datetime import datetime, timezone
-from typing import Union
 
 
 RE_RFC3339 = re.compile(
@@ -63,49 +62,54 @@ def uint_b64decode(uint_b64: str) -> int:
     return value
 
 
-def get_time(value: Union[str, int, datetime]) -> Union[int, datetime, None]:
+def get_time_from_int(value: int) -> [datetime]:
     """
-    :param value: The value of time to convert
-                  If is str or int datetime or None will be returned
-                  If is datetime int will be returned
-    :return: None if the string is not valid
-             datetime if is valid str or int
-             int if value is datetime
+    :param value: seconds since the Epoch
+    :return: None if int is invalid else datetime
     """
-    returned = None
-    if isinstance(value, str):
-        is_rfc3339 = RE_RFC3339.match(value)
-        if is_rfc3339:
-            rfc3339 = is_rfc3339.groupdict()
-            tz = '+0000'
-            try:
-                if rfc3339.get('timezone'):
-                    tz = '{}{}{}'.format(
-                        rfc3339.get('symbol'),
-                        rfc3339.get('hour'),
-                        rfc3339.get('minute'),
-                    )
-                returned = datetime.strptime(
-                    rfc3339.get('datetime')+tz,
-                    '%Y-%m-%dT%H:%M:%S%z'
-                ).astimezone(timezone.utc)
-            except ValueError:
-                pass
-        else:
-            try:
-                value = int(value)
-            except ValueError:
-                pass
-
     if isinstance(value, int):
         returned = datetime.utcfromtimestamp(value)
         # Add the UTC timezone
-        returned = datetime.strptime(
+        return datetime.strptime(
             returned.strftime('%Y-%m-%dT%H:%M:%S') + '+0000',
             '%Y-%m-%dT%H:%M:%S%z'
         )
 
-    elif isinstance(value, datetime):
-        returned = int(value.timestamp())
 
-    return returned
+def get_time_from_str(value: str) -> [datetime]:
+    """
+    :param value: Str defined as RFC339
+                  Or int as str for seconds since the Epoch
+    :return: None if the string is invalid else datetime
+    """
+    is_rfc3339 = RE_RFC3339.match(value)
+    if is_rfc3339:
+        rfc3339 = is_rfc3339.groupdict()
+        tz = '+0000'
+        try:
+            if rfc3339.get('timezone'):
+                tz = '{}{}{}'.format(
+                    rfc3339.get('symbol'),
+                    rfc3339.get('hour'),
+                    rfc3339.get('minute'),
+                )
+            return datetime.strptime(
+                rfc3339.get('datetime') + tz,
+                '%Y-%m-%dT%H:%M:%S%z'
+            ).astimezone(timezone.utc)
+        except ValueError:
+            pass
+    else:
+        try:
+            return get_time_from_int(int(value))
+        except ValueError:
+            pass
+
+
+def get_int_from_datetime(value: datetime) -> [int]:
+    """
+    :param value: datetime with or without timezone, if don't contains timezone it will managed as it is UTC
+    :return: None if value is not datetime else seconds since the Epoch
+    """
+    if isinstance(value, datetime):
+        return int(value.timestamp())

--- a/jwt/utils.py
+++ b/jwt/utils.py
@@ -13,10 +13,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 from base64 import (
     urlsafe_b64encode,
     urlsafe_b64decode,
+)
+
+from datetime import datetime, timezone
+from typing import Union
+
+
+RE_RFC3339 = re.compile(
+    '(?P<datetime>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:(?P<leap>\d{2}))'
+    '(?P<float>\.\d+)?'
+    '(Z|(?P<timezone>(?P<symbol>[+\-])(?P<hour>\d{2}):(?P<minute>\d{2})))?'
 )
 
 
@@ -51,3 +61,51 @@ def uint_b64decode(uint_b64: str) -> int:
         value <<= 8
         value += int(b)
     return value
+
+
+def get_time(value: Union[str, int, datetime]) -> Union[int, datetime, None]:
+    """
+    :param value: The value of time to convert
+                  If is str or int datetime or None will be returned
+                  If is datetime int will be returned
+    :return: None if the string is not valid
+             datetime if is valid str or int
+             int if value is datetime
+    """
+    returned = None
+    if isinstance(value, str):
+        is_rfc3339 = RE_RFC3339.match(value)
+        if is_rfc3339:
+            rfc3339 = is_rfc3339.groupdict()
+            tz = '+0000'
+            try:
+                if rfc3339.get('timezone'):
+                    tz = '{}{}{}'.format(
+                        rfc3339.get('symbol'),
+                        rfc3339.get('hour'),
+                        rfc3339.get('minute'),
+                    )
+                returned = datetime.strptime(
+                    rfc3339.get('datetime')+tz,
+                    '%Y-%m-%dT%H:%M:%S%z'
+                ).astimezone(timezone.utc)
+            except ValueError:
+                pass
+        else:
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+    if isinstance(value, int):
+        returned = datetime.utcfromtimestamp(value)
+        # Add the UTC timezone
+        returned = datetime.strptime(
+            returned.strftime('%Y-%m-%dT%H:%M:%S') + '+0000',
+            '%Y-%m-%dT%H:%M:%S%z'
+        )
+
+    elif isinstance(value, datetime):
+        returned = int(value.timestamp())
+
+    return returned

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ envlist = py35, py36, py37
 deps = pytest
        pytest-cov
        pytest-pep8
+       freezegun
 commands = py.test --capture=no --cov jwt --cov-report term-missing jwt


### PR DESCRIPTION
Add support for manage exp and nbf fields as is described on [rfc7519 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4) and [rfc7519 4.1.5](https://tools.ietf.org/html/rfc7519#section-4.1.5) 
Also I created on utils a parser for [rfc3339](https://tools.ietf.org/html/rfc3339) dates
